### PR TITLE
Upgrade package to be koa@2 and node@8 compatible

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
     "extends": "vgno",
-    "ecmaFeatures": {
-        "generators": true
+    "parserOptions": {
+        "ecmaVersion": 2017
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 *.log
 .DS_Store
 coverage
+package-lock.json
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-    - 0.12
-    - 4
-    - 5
+    - 7.6
+    - 8
 after_script:
     - cat coverage/lcov.info | node_modules/.bin/coveralls

--- a/index.js
+++ b/index.js
@@ -13,32 +13,32 @@ function lowercasePath(opts) {
         opts.chained = opts.chained || true;
     }
 
-    return function* (next) {
+    return async function(ctx, next) {
         if (opts.defer) {
-            yield next;
+            await next();
         }
 
-        var path;
+        let path;
 
         // We have already done a redirect and we will continue if we are in chained mode
-        if (opts.chained && this.status === 301) {
-            path = getPath(this.response.get('Location'), this.querystring);
-        } else if (this.status !== 301) {
-            path = getPath(this.originalUrl, this.querystring);
+        if (opts.chained && ctx.status === 301) {
+            path = getPath(ctx.response.get('Location'), ctx.querystring);
+        } else if (ctx.status !== 301) {
+            path = getPath(ctx.originalUrl, ctx.querystring);
         }
 
-        if (path && (!this.body || this.status !== 200)) {
-            var lowercasedPath = path.toLowerCase();
+        if (path && (!ctx.body || ctx.status !== 200)) {
+            const lowercasedPath = path.toLowerCase();
             if (path !== lowercasedPath) {
-                var query = this.querystring.length ? '?' + this.querystring : '';
+                const query = ctx.querystring.length ? '?' + ctx.querystring : '';
 
-                this.status = 301;
-                this.redirect(path.toLowerCase() + query);
+                ctx.status = 301;
+                ctx.redirect(path.toLowerCase() + query);
             }
         }
 
         if (!opts.defer) {
-            yield next;
+            await next();
         }
     };
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "license": "MIT",
   "devDependencies": {
     "coveralls": "~2.11.6",
-    "eslint": "~1.10.3",
-    "eslint-config-vgno": "~5.0.0",
+    "eslint": "~4.16.0",
+    "eslint-config-vgno": "~7.0.0",
     "expect": "~1.13.4",
     "istanbul": "~0.4.2",
     "mocha": "~2.3.4"

--- a/test/index.js
+++ b/test/index.js
@@ -1,126 +1,110 @@
 'use strict';
 
-var expect = require('expect');
-var lowercasePath = require('../index.js');
+const expect = require('expect');
+const lowercasePath = require('../');
 
-describe('koa-lowercase-path', function() {
-    describe('defer = false', function() {
-        it('should redirect on url and path has uppercase characters', function() {
-            var mock = createMock('/fOo');
-            var lowercasePathMock = lowercasePath({defer: false}).bind(mock.this);
-            var lowercasePathMockGenerator = lowercasePathMock();
-            lowercasePathMockGenerator.next();
+describe('koa-lowercase-path', () => {
+    describe('defer = false', () => {
+        it('should redirect on url and path has uppercase characters', async () => {
+            const mock = createMock('/fOo');
+            await lowercasePath({defer: false})(mock.ctx, mock.next);
+
             expect(mock.redirectMock.calls[0].arguments[0]).toEqual('/foo');
-            expect(mock.this.status).toBe(301);
+            expect(mock.ctx.status).toBe(301);
         });
     });
 
-    describe('chained = false', function() {
-        it('should not redirect on url that already have been modified', function() {
-            var mock = createMock('/fOo/');
+    describe('chained = false', () => {
+        it('should not redirect on url that already have been modified', async () => {
+            const mock = createMock('/fOo/');
 
             // Mock that something has made a redirect before us
-            mock.this.status = 301;
-            mock.this.body = 'Redirecting to …';
-            mock.this.response = {
+            mock.ctx.status = 301;
+            mock.ctx.body = 'Redirecting to …';
+            mock.ctx.response = {
                 get: function() {
                     return '/fOo';
                 }
             };
 
-            var lowercasePathMock = lowercasePath({chained: false}).bind(mock.this);
-            var lowercasePathMockGenerator = lowercasePathMock();
-            lowercasePathMockGenerator.next();
-            lowercasePathMockGenerator.next();
+            await lowercasePath({chained: false})(mock.ctx, mock.next);
+
             expect(mock.redirectMock).toNotHaveBeenCalled();
-            expect(mock.this.status).toBe(301);
+            expect(mock.ctx.status).toBe(301);
         });
     });
 
-    describe('chained = true & defer = true', function() {
-        describe('redirect', function() {
-            it('should redirect on url that already have been modified and path has upercase characters', function() {
-                var mock = createMock('/fOo/');
+    describe('chained = true & defer = true', () => {
+        describe('redirect', () => {
+            it('should redirect on url that already have been modified and path has upercase characters', async () => {
+                const mock = createMock('/fOo/');
 
                 // Mock that something has made a redirect before us
-                mock.this.status = 301;
-                mock.this.body = 'Redirecting to …';
-                mock.this.response = {
+                mock.ctx.status = 301;
+                mock.ctx.body = 'Redirecting to …';
+                mock.ctx.response = {
                     get: function() {
                         return '/fOo';
                     }
                 };
 
-                var lowercasePathMock = lowercasePath().bind(mock.this);
-                var lowercasePathMockGenerator = lowercasePathMock();
-                lowercasePathMockGenerator.next();
-                lowercasePathMockGenerator.next();
+                await lowercasePath()(mock.ctx, mock.next);
+
                 expect(mock.redirectMock.calls[0].arguments[0]).toEqual('/foo');
-                expect(mock.this.status).toBe(301);
+                expect(mock.ctx.status).toBe(301);
             });
 
-            it('should redirect on simple path and path has uppercase characters', function() {
-                var mock = createMock('/fOo');
-                var lowercasePathMock = lowercasePath().bind(mock.this);
-                var lowercasePathMockGenerator = lowercasePathMock();
-                lowercasePathMockGenerator.next();
-                lowercasePathMockGenerator.next();
+            it('should redirect on simple path and path has uppercase characters', async () => {
+                const mock = createMock('/fOo');
+                await lowercasePath()(mock.ctx, mock.next);
+
                 expect(mock.redirectMock.calls[0].arguments[0]).toEqual('/foo');
-                expect(mock.this.status).toBe(301);
+                expect(mock.ctx.status).toBe(301);
             });
 
-            it('should redirect on simple path and path has uppercase characters and query', function() {
-                var mock = createMock('/fOo?hello=wOrld', 'hello=wOrld');
-                var lowercasePathMock = lowercasePath().bind(mock.this);
-                var lowercasePathMockGenerator = lowercasePathMock();
-                lowercasePathMockGenerator.next();
-                lowercasePathMockGenerator.next();
+            it('should redirect on simple path and path has uppercase characters and query', async () => {
+                const mock = createMock('/fOo?hello=wOrld', 'hello=wOrld');
+                await lowercasePath()(mock.ctx, mock.next);
+
                 expect(mock.redirectMock.calls[0].arguments[0]).toEqual('/foo?hello=wOrld');
-                expect(mock.this.status).toBe(301);
+                expect(mock.ctx.status).toBe(301);
             });
 
-            it('should redirect on UTF-8 path and path has uppercase characters', function() {
-                var mock = createMock('/fØö/БАЯ');
-                var lowercasePathMock = lowercasePath().bind(mock.this);
-                var lowercasePathMockGenerator = lowercasePathMock();
-                lowercasePathMockGenerator.next();
-                lowercasePathMockGenerator.next();
+            it('should redirect on UTF-8 path and path has uppercase characters', async () => {
+                const mock = createMock('/fØö/БАЯ');
+                await lowercasePath()(mock.ctx, mock.next);
+
                 expect(mock.redirectMock.calls[0].arguments[0]).toEqual('/føö/бая');
-                expect(mock.this.status).toBe(301);
+                expect(mock.ctx.status).toBe(301);
             });
         });
 
-        describe('not redirect', function() {
-            it('should not redirect on simple path that is all lowercase', function() {
-                var mock = createMock('/foo');
-                var lowercasePathMock = lowercasePath().bind(mock.this);
-                var lowercasePathMockGenerator = lowercasePathMock();
-                lowercasePathMockGenerator.next();
-                lowercasePathMockGenerator.next();
+        describe('not redirect', () => {
+            it('should not redirect on simple path that is all lowercase', async () => {
+                const mock = createMock('/foo');
+                await lowercasePath()(mock.ctx, mock.next);
+
                 expect(mock.redirectMock).toNotHaveBeenCalled();
-                expect(mock.this.status).toBe(undefined);
+                expect(mock.ctx.status).toBe(undefined);
             });
 
-            it('should not redirect on simple path that is all lowercase and have query', function() {
-                var mock = createMock('/foo?hello=wOrld', 'hello=wOrld');
-                var lowercasePathMock = lowercasePath().bind(mock.this);
-                var lowercasePathMockGenerator = lowercasePathMock();
-                lowercasePathMockGenerator.next();
-                lowercasePathMockGenerator.next();
+            it('should not redirect on simple path that is all lowercase and have query', async () => {
+                const mock = createMock('/foo?hello=wOrld', 'hello=wOrld');
+                await lowercasePath()(mock.ctx, mock.next);
+
                 expect(mock.redirectMock).toNotHaveBeenCalled();
-                expect(mock.this.status).toBe(undefined);
+                expect(mock.ctx.status).toBe(undefined);
             });
 
-            it('should not redirect on when body is defined', function() {
-                var mock = createMock('/fOo?hello=wOrld', 'hello=wOrld');
-                var lowercasePathMock = lowercasePath().bind(mock.this);
-                var lowercasePathMockGenerator = lowercasePathMock();
-                lowercasePathMockGenerator.next();
-                mock.this.body = 'some content';
-                mock.this.status = 200;
-                lowercasePathMockGenerator.next();
+            it('should not redirect on when body is defined', async () => {
+                const mock = createMock('/fOo?hello=wOrld', 'hello=wOrld');
+                mock.ctx.body = 'some content';
+                mock.ctx.status = 200;
+
+                await lowercasePath()(mock.ctx, mock.next);
+
                 expect(mock.redirectMock).toNotHaveBeenCalled();
-                expect(mock.this.status).toBe(200);
+                expect(mock.ctx.status).toBe(200);
             });
         });
     });
@@ -128,14 +112,15 @@ describe('koa-lowercase-path', function() {
 
 function createMock(originalUrl, querystring) {
     querystring = querystring || '';
-    var redirectMock = expect.createSpy();
+    const redirectMock = expect.createSpy();
     return {
         redirectMock: redirectMock,
-        this: {
+        ctx: {
             originalUrl: originalUrl,
             querystring: querystring,
             status: undefined,
             redirect: redirectMock
-        }
+        },
+        next: async () => {}
     };
 }


### PR DESCRIPTION
**Summary**
- [x] Upgrades package to use `async/await` required in `koa@2`
- [x] Bumps travis to `node@8`
- [x] Upgrades `eslint` since it was a little ancient and didn't support `async/await`

This is obviously a breaking change and should be released as a `major` bump.